### PR TITLE
Update usage.rst: change Homebrew package name

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -91,4 +91,4 @@ Homebrew
 
 fmt can be installed on OS X using `Homebrew <http://brew.sh/>`_::
 
-  brew install cppformat
+  brew install fmt


### PR DESCRIPTION
Homebrew package name was changed from cppformat to fmt.
https://github.com/Homebrew/homebrew-core/commit/1e1dfe43b8e69709b1223e1d5182135bc47cbae9
